### PR TITLE
Added updated url-templates definitions from jtamayo/DefinitelyTyped

### DIFF
--- a/uri-templates/uri-templates-0.1.2.d.ts
+++ b/uri-templates/uri-templates-0.1.2.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for uri-templates 0.1.2
+// Project: https://github.com/geraintluff/uri-templates
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module 'uri-templates' {
+	function utpl(template: string): utpl.URITemplate;
+
+	module utpl {
+		export interface URITemplate {
+			fillFromObject(vars: Object): string;
+			fill(callback: (varName: string) => string): string;
+			fromUri(uri: string): Object;
+		}
+	}
+
+	export = utpl;
+}

--- a/uri-templates/uri-templates-tests-0.1.2.ts
+++ b/uri-templates/uri-templates-tests-0.1.2.ts
@@ -1,0 +1,16 @@
+/// <reference path="uri-templates-0.1.2.d.ts" />
+
+import utmpl = require('uri-templates');
+import URITemplate = utmpl.URITemplate;
+
+var str: string;
+var u: URITemplate;
+var obj: Object;
+
+u = utmpl(str);
+
+str = u.fillFromObject(obj);
+str = u.fill((key) => {
+	return str;
+});
+obj = u.fromUri(str);

--- a/uri-templates/uri-templates-tests.ts
+++ b/uri-templates/uri-templates-tests.ts
@@ -1,16 +1,26 @@
 /// <reference path="uri-templates.d.ts" />
 
-import utmpl = require('uri-templates');
-import URITemplate = utmpl.URITemplate;
+var template1 = new UriTemplate("/prefix/{?params*}");;
+var template2 = new UriTemplate("/prefix/{?params*}");
 
-var str: string;
-var u: URITemplate;
-var obj: Object;
-
-u = utmpl(str);
-
-str = u.fillFromObject(obj);
-str = u.fill((key) => {
-	return str;
+// Substitution using an object
+// "/categories/green/round/"
+var uri1 = template1.fillFromObject({colour: "green", shape: "round"});
+// "/prefix/?a=A&b=B&c=C
+var uri2 = template2.fillFromObject({
+    params: {a: "A", b: "B", c: "C"}
 });
-obj = u.fromUri(str);
+
+// Substitution using a callback
+// "/categories/example_colour/example_shape/"
+var uri1b = template1.fill(function (varName) {
+    return "example_" + varName;
+});
+
+// Guess variables from URI ("de-substitution")
+var url2b = "/prefix/?beep=boop&bleep=bloop";
+var params = template2.fromUri(url2b);
+
+// Extended test cases
+var template = new UriTemplate("{/id*}{?fields,token}");
+var values = template.fromUri("/person/albums?fields=id,name,picture&token=12345");

--- a/uri-templates/uri-templates.d.ts
+++ b/uri-templates/uri-templates.d.ts
@@ -1,18 +1,19 @@
-// Type definitions for uri-templates 0.1.2
+// Type definitions for uri-templates 0.1.5
 // Project: https://github.com/geraintluff/uri-templates
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Juan M Tamayo <https://github.com/jtamayo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module 'uri-templates' {
-	function utpl(template: string): utpl.URITemplate;
+declare class UriTemplate {
+    constructor(template: string);
+    fillFromObject(vars: Object): string;
+    fill(callback: (varName: string) => string): string;
+    fromUri(uri: string): Object;
+}
 
-	module utpl {
-		export interface URITemplate {
-			fillFromObject(vars: Object): string;
-			fill(callback: (varName: string) => string): string;
-			fromUri(uri: string): Object;
-		}
-	}
+interface UriTemplateFactory {
+    (template: string): typeof UriTemplate;
+}
 
-	export = utpl;
+declare module "uri-templates" {
+    export = UriTemplateFactory;
 }

--- a/uri-templates/uri-templates.d.ts
+++ b/uri-templates/uri-templates.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for uri-templates 0.1.5
 // Project: https://github.com/geraintluff/uri-templates
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
-// Definitions by: Juan M Tamayo <https://github.com/jtamayo>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Juan Tamayo <https://github.com/jtamayo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 declare class UriTemplate {

--- a/uri-templates/uri-templates.d.ts
+++ b/uri-templates/uri-templates.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for uri-templates 0.1.5
 // Project: https://github.com/geraintluff/uri-templates
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions by: Juan M Tamayo <https://github.com/jtamayo>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 


### PR DESCRIPTION
This just combines the latest definitions from **[borisyankov/DefinitelyTyped](https://github.com/borisyankov/DefinitelyTyped)** with **[jtamayo/DefinitelyTyped](https://github.com/jtamayo/DefinitelyTyped)** to include fixes in the definition for the [uri-templates](https://github.com/geraintluff/uri-templates) library.
